### PR TITLE
adhere to java11 module system

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
 plugins {
   id "java"
-  id "maven"
+  // id "maven"
   id "signing"
 }
 
@@ -21,24 +21,23 @@ apply plugin: 'biz.aQute.bnd.builder'
 
 repositories {
   mavenCentral()
-  maven { url "http://maven.restlet.org" }
-  maven { url "http://developer.marklogic.com/maven2" }
+  maven { url "https://maven.restlet.org" }
+  maven { url "https://developer.marklogic.com/maven2" }
   maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
 }
 
 configurations {
   localLibs
 
-  copydep {
-    extendsFrom runtime
-  }
+  copydep.extendsFrom(runtime)
   copydep.exclude module: 'xmlcalabash'
   copydep.exclude module: 'nwalsh-annotations'
 }
 
 dependencies {
   localLibs fileTree(dir: 'lib').include("*.jar")
-  compile (
+
+  implementation (
     [group: 'com.nwalsh', name: 'nwalsh-annotations', version: '1.0.0'],
     [group: 'com.xmlcalabash', name: 'xmlcalabash', version: '1.1.27-99'],
     [group: 'org.apache.xmlgraphics', name: 'fop', version: '2.3'],
@@ -167,6 +166,7 @@ signing {
   sign configurations.archives
 }
 
+/*
 uploadArchives {
   repositories {
     mavenDeployer {
@@ -211,3 +211,5 @@ uploadArchives {
     }
   }
 }
+*/
+

--- a/build.gradle
+++ b/build.gradle
@@ -140,7 +140,9 @@ task testStep(type: JavaExec) {
 }
 
 task makeDist(dependsOn: [ build, copyJar, copyLib ]) {
-  println "Created distribution in build/dist"
+  doLast {
+    println "Created distribution in build/dist"
+  }
 }
 
 task zipDist(dependsOn: makeDist, type: Zip) {
@@ -150,7 +152,9 @@ task zipDist(dependsOn: makeDist, type: Zip) {
 }
 
 task dist(dependsOn: zipDist) {
-  // nop
+  doLast {
+    // nop
+  }
 }
 
 artifacts {

--- a/src/main/java/com/xmlcalabash/util/print/CssAH.java
+++ b/src/main/java/com/xmlcalabash/util/print/CssAH.java
@@ -1,22 +1,33 @@
-package com.xmlcalabash.util;
+package com.xmlcalabash.util.print;
 
-import com.xmlcalabash.config.FoProcessor;
+import com.xmlcalabash.config.CssProcessor;
 import com.xmlcalabash.core.XProcConstants;
 import com.xmlcalabash.core.XProcException;
 import com.xmlcalabash.core.XProcRuntime;
 import com.xmlcalabash.runtime.XStep;
+import com.xmlcalabash.util.Base64;
+import com.xmlcalabash.util.MessageFormatter;
+import com.xmlcalabash.util.S9apiUtils;
 import jp.co.antenna.XfoJavaCtl.MessageListener;
 import jp.co.antenna.XfoJavaCtl.XfoException;
 import jp.co.antenna.XfoJavaCtl.XfoFormatPageListener;
 import jp.co.antenna.XfoJavaCtl.XfoObj;
+import net.sf.saxon.s9api.QName;
 import net.sf.saxon.s9api.SaxonApiException;
 import net.sf.saxon.s9api.Serializer;
 import net.sf.saxon.s9api.XdmNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
 import java.util.Properties;
+import java.util.Vector;
 
 /**
  * Created by IntelliJ IDEA.
@@ -25,10 +36,16 @@ import java.util.Properties;
  * Time: 4:24 PM
  * To change this template use File | Settings | File Templates.
  */
-public class FoAH implements FoProcessor {
-    private Logger logger = LoggerFactory.getLogger(FoAH.class);
+public class CssAH implements CssProcessor {
+    private Logger logger = LoggerFactory.getLogger(CssAH.class);
+    private static final QName _content_type = new QName("content-type");
+    private static final QName _encoding = new QName("", "encoding");
+
     XProcRuntime runtime = null;
     Properties options = null;
+    String primarySS = null;
+    Vector<String> userSS = new Vector<String> ();
+
     XStep step = null;
     XfoObj ah = null;
 
@@ -36,10 +53,9 @@ public class FoAH implements FoProcessor {
         this.runtime = runtime;
         this.step = step;
         this.options = options;
-
         try {
             ah = new XfoObj();
-            ah.setFormatterType(XfoObj.S_FORMATTERTYPE_XSLFO);
+            ah.setFormatterType(XfoObj.S_FORMATTERTYPE_XMLCSS);
             FoMessages msgs = new FoMessages();
             ah.setMessageListener(msgs);
 
@@ -54,9 +70,17 @@ public class FoAH implements FoProcessor {
                 ah.setExitLevel(i);
             }
 
-            i = getIntProp("EmbedAllFontsEx");
-            if (i != null) {
-                ah.setPdfEmbedAllFontsEx(i);
+            s = getStringProp("EmbedAllFontsEx");
+            if (s != null) {
+                if ("part".equals(s.toLowerCase())) {
+                    ah.setPdfEmbedAllFontsEx(XfoObj.S_PDF_EMBALLFONT_PART);
+                } else if ("base14".equals(s.toLowerCase())) {
+                    ah.setPdfEmbedAllFontsEx(XfoObj.S_PDF_EMBALLFONT_BASE14);
+                } else if ("all".equals(s.toLowerCase())) {
+                    ah.setPdfEmbedAllFontsEx(XfoObj.S_PDF_EMBALLFONT_ALL);
+                } else {
+                    throw new XProcException("Unrecognized value for EmbedAllFontsEx");
+                }
             }
 
             i = getIntProp("ImageCompression");
@@ -112,6 +136,55 @@ public class FoAH implements FoProcessor {
             throw new XProcException(xfoe);
         }
     }
+
+    public void addStylesheet(String uri) {
+        if (primarySS == null) {
+            primarySS = uri;
+        } else {
+            userSS.add(uri);
+        }
+    }
+
+    public void addStylesheet(XdmNode doc) {
+        doc = S9apiUtils.getDocumentElement(doc);
+
+        String stylesheet = null;
+        if ((XProcConstants.c_data.equals(doc.getNodeName())
+                && "application/octet-stream".equals(doc.getAttributeValue(_content_type)))
+                || "base64".equals(doc.getAttributeValue(_encoding))) {
+            byte[] decoded = Base64.decode(doc.getStringValue());
+            stylesheet = new String(decoded);
+        } else {
+            stylesheet = doc.getStringValue();
+        }
+
+        String prefix = "temp";
+        String suffix = ".css";
+
+        File temp;
+        try {
+            temp = File.createTempFile(prefix, suffix);
+        } catch (IOException ioe) {
+            throw new XProcException(step.getNode(), "Failed to create temporary file for CSS");
+        }
+
+        temp.deleteOnExit();
+
+        try {
+            PrintStream cssout = new PrintStream(temp);
+            cssout.print(stylesheet);
+            cssout.close();
+        } catch (FileNotFoundException fnfe) {
+            throw new XProcException(step.getNode(), "Failed to write to temporary CSS file");
+        }
+
+        if (primarySS == null) {
+            primarySS = temp.toURI().toASCIIString();
+        } else {
+            userSS.add(temp.toURI().toASCIIString());
+        }
+    }
+
     public void format(XdmNode doc, OutputStream out, String contentType) {
         String outputFormat = null;
         if (contentType == null || "application/pdf".equals(contentType)) {
@@ -125,12 +198,22 @@ public class FoAH implements FoProcessor {
         } else if ("application/vnd.mif".equals(contentType)) {
             outputFormat = "@MIF";
         } else if ("text/plain".equals(contentType)) {
-            outputFormat = "@TEXT";
+            outputFormat = "@TXT";
         } else {
             throw new XProcException(step.getNode(), "Unsupported content-type on p:xsl-formatter: " + contentType);
         }
 
         try {
+            if (primarySS == null) {
+                throw new XProcException("No CSS stylesheets provided");
+            } else {
+                ah.setStylesheetURI(primarySS);
+            }
+
+            for (String uri : userSS) {
+                ah.addUserStylesheetURI(uri);
+            }
+
             Serializer serializer = runtime.getProcessor().newSerializer();
             serializer.setOutputProperty(Serializer.Property.METHOD, "xml");
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -158,8 +241,7 @@ public class FoAH implements FoProcessor {
         String s = getStringProp(name);
         if (s != null) {
             try {
-                int i = Integer.parseInt(s);
-                return new Integer(i);
+                return Integer.parseInt(s);
             } catch (NumberFormatException nfe) {
                 return null;
             }

--- a/src/main/java/com/xmlcalabash/util/print/CssPrince.java
+++ b/src/main/java/com/xmlcalabash/util/print/CssPrince.java
@@ -1,4 +1,4 @@
-package com.xmlcalabash.util;
+package com.xmlcalabash.util.print;
 
 import com.princexml.Prince;
 import com.princexml.PrinceEvents;
@@ -7,6 +7,8 @@ import com.xmlcalabash.core.XProcConstants;
 import com.xmlcalabash.core.XProcException;
 import com.xmlcalabash.core.XProcRuntime;
 import com.xmlcalabash.runtime.XStep;
+import com.xmlcalabash.util.Base64;
+import com.xmlcalabash.util.S9apiUtils;
 import net.sf.saxon.s9api.QName;
 import net.sf.saxon.s9api.SaxonApiException;
 import net.sf.saxon.s9api.Serializer;
@@ -21,7 +23,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
-import java.io.UnsupportedEncodingException;
 import java.util.Properties;
 import java.util.Vector;
 

--- a/src/main/java/com/xmlcalabash/util/print/FoFOP.java
+++ b/src/main/java/com/xmlcalabash/util/print/FoFOP.java
@@ -1,9 +1,10 @@
-package com.xmlcalabash.util;
+package com.xmlcalabash.util.print;
 
 import com.xmlcalabash.config.FoProcessor;
 import com.xmlcalabash.core.XProcException;
 import com.xmlcalabash.core.XProcRuntime;
 import com.xmlcalabash.runtime.XStep;
+import com.xmlcalabash.util.S9apiUtils;
 import net.sf.saxon.s9api.XdmNode;
 import org.apache.avalon.framework.configuration.Configuration;
 import org.apache.avalon.framework.configuration.DefaultConfigurationBuilder;

--- a/src/main/java/com/xmlcalabash/util/print/FoXEP.java
+++ b/src/main/java/com/xmlcalabash/util/print/FoXEP.java
@@ -1,4 +1,4 @@
-package com.xmlcalabash.util;
+package com.xmlcalabash.util.print;
 
 import com.renderx.xep.FOTarget;
 import com.renderx.xep.FormatterImpl;
@@ -9,6 +9,8 @@ import com.xmlcalabash.core.XProcConstants;
 import com.xmlcalabash.core.XProcException;
 import com.xmlcalabash.core.XProcRuntime;
 import com.xmlcalabash.runtime.XStep;
+import com.xmlcalabash.util.MessageFormatter;
+import com.xmlcalabash.util.S9apiUtils;
 import net.sf.saxon.s9api.XdmNode;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.InputSource;


### PR DESCRIPTION
When I use the jar with java 11 I get the following error:

```
java.lang.module.ResolutionException: Modules xmlcalabash1.print and xmlcalabash export package com.xmlcalabash.util to module joda.time
```

This is because the jars share some (java class) code in the same package (namely `com.xmlcalabash.util`).

The new java 11 (or java 9) module system does not like this kind of 'split jars'. The agreed-upon long-term solution to split jars is to separate the package namespaces. This is what I did. In detail:

* I moved `com.xmlcalabash.util`  of this jar (xmlcalabash1-print) to its 'own' package `com.xmlcalabash.util.print`
* In additon I replaced the gradle `<<` operator with `doLast` as `leftShift` is not available any more with gradle 5+.

I would be glad it you could consider integration into branch master.

Kind regards,

aanno